### PR TITLE
Fix typo in user_repository.dart

### DIFF
--- a/lib/api/repositories/user_repository.dart
+++ b/lib/api/repositories/user_repository.dart
@@ -77,7 +77,7 @@ class UserRepository implements IUser {
         print(response.data);
       }
       final user = response.data['user'];
-      final products = user['products'];
+      final products = user['Product'];
       return products == null || products.isEmpty;
     } on DioException catch (e) {
       if (e.response?.statusCode == 404) {


### PR DESCRIPTION
A PR (Pull Request) foi aberta para resolver um problema identificado no arquivo `user_repository.dart` relacionado ao acesso aos dados de produtos do usuário. Especificamente, a chave para acessar os produtos no JSON retornado pela API estava incorreta.

### Explicação do Problema:
No código original, os produtos do usuário estavam sendo acessados com a chave `'products'`:
```dart
final products = user['products'];
```
Isso gerava um problema, pois a chave correta, de acordo com a resposta da API, era `'Product'` (com "P" maiúsculo).

### Solução:
A PR ajustou o código para acessar os produtos do usuário com a chave correta:
```dart
final products = user['Product'];
```
Isso garantiu que o aplicativo pudesse acessar os dados de produtos corretamente, evitando erros ao lidar com uma resposta da API onde essa chave específica era utilizada.

No contexto do repositório e da issue referenciada, essa mudança foi necessária para alinhar o código com a estrutura de dados esperada da API, resolvendo a falha na obtenção de informações sobre os produtos do usuário. 

Essa correção simples evita problemas como retornos vazios ou nulos ao tentar acessar os produtos, o que poderia comprometer a funcionalidade da aplicação.